### PR TITLE
Dockerized LIT tracker and allow remote Mongo server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:alpine AS dependencies
+# install node packages
+WORKDIR /app
+COPY package.json .
+RUN npm set progress=false && npm config set depth 0
+RUN npm install --only=production 
+# copy production node_modules aside
+RUN cp -R node_modules prod_node_modules
+# install ALL node_modules, including 'devDependencies'
+RUN npm install
+
+#
+# ---- Release ----
+FROM node:alpine AS release
+# copy production node_modules
+COPY --from=dependencies /app/prod_node_modules ./node_modules
+# copy app sources
+COPY . .
+# expose port and define CMD
+EXPOSE 46580
+CMD node server.js

--- a/config/config.js
+++ b/config/config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    database : 'mongodb://localhost/lit-tracker',
+    database : 'mongodb://' + (process.env.DB_HOST || 'localhost') + '/' + (process.env.DB_NAME || 'lit-tracker'),
 };


### PR DESCRIPTION
I added a Dockerfile so you can run the tracker in a container, as well as made the mongo endpoint configurable through environments, so you can run it against a separate mongo container.